### PR TITLE
chore: refinamento do .gitignore para ambiente python, firebase e ferramentas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,37 @@
 # Python
 __pycache__/
 *.py[cod]
-venv_triagem/
+*$py.class
 venv/
+.venv/
 .env
+venv_triagem/
 
 # Firebase
 .firebase/
 *-debug.log
+firebase-debug.log*
+firestore-debug.log*
+ui-debug.log*
+.runtimeconfig.json
 
-# OS & IDE
-.DS_Store
+# IDEs
 .vscode/
+.idea/
+.DS_Store
 
-# Pastas de Auditoria/Temporários
+# Playwright & Scrapers
 auditoria_visual/
-scratch/
+scripts/playwright_profile/
+.auth/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
+# System / Agents / Temp
 .agents/
 .antigravity/
-scripts/playwright_profile/
-scripts/playwright_profile/
+scratch/
+npx
+test_video.py


### PR DESCRIPTION
- [x] Refinamento do .gitignore para evitar poluição do repositório com caches do Playwright e arquivos de sistema.